### PR TITLE
-bookspot +denira

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -30,6 +30,12 @@
 
 <body data-sveltekit-preload-data="hover">
 	<div style="display: contents">%sveltekit.body%</div>
+	<script
+		async
+		src="https://www.denira.io/widget.js"
+		data-denira-merchant="stisses-sport-och-fritid-ab"
+		data-denira-api="https://incredible-vole-761.convex.site"
+	></script>
 </body>
 
 </html>

--- a/src/lib/components/ActivityLayout.svelte
+++ b/src/lib/components/ActivityLayout.svelte
@@ -63,8 +63,8 @@
 		</button>
 
 		<ExperienceDetails experience={currentExperience} />
-		{#if currentExperience.bookingLink}
-			<BookingButton bookingLink={currentExperience.bookingLink} sticky={true} />
+		{#if currentExperience.deniraWidgetId}
+			<BookingButton widgetId={currentExperience.deniraWidgetId} />
 		{/if}
 	</div>
 {:else}

--- a/src/lib/components/BookingButton.svelte
+++ b/src/lib/components/BookingButton.svelte
@@ -1,27 +1,7 @@
 <script lang="ts">
-	export let bookingLink: string;
-	export let sticky = false;
-	import * as m from '$lib/paraglide/messages';
+	export let widgetId: string;
 </script>
 
-{#if sticky}
-	<div class="fixed bottom-8 right-8 z-50">
-		<a
-			href={bookingLink}
-			target="_blank"
-			rel="noopener noreferrer"
-			class="inline-block rounded-lg bg-blue-600 px-6 py-3 text-center font-semibold text-white shadow-lg transition-all hover:scale-105 hover:bg-blue-700 hover:shadow-xl"
-		>
-			{m.polite_sour_mongoose_bump()}
-		</a>
-	</div>
-{:else}
-	<a
-		href={bookingLink}
-		target="_blank"
-		rel="noopener noreferrer"
-		class="inline-block rounded-lg bg-blue-600 px-6 py-3 text-center font-semibold text-white shadow-md transition-all hover:bg-blue-700 hover:shadow-lg"
-	>
-		{m.polite_sour_mongoose_bump()}
-	</a>
-{/if}
+<div class="mt-8 w-full">
+	<div data-denira-widget={widgetId}></div>
+</div>

--- a/src/lib/data/activities/paddla.ts
+++ b/src/lib/data/activities/paddla.ts
@@ -42,7 +42,7 @@ export const activities: { paddla: Activity } = {
                     children: 3
                 },
                 bookingRules: bookingRulesPrivate,
-                bookingLink: "https://app.bookspot.io/widget/v2/dialog/new-order?key=e288265c8bfe259e7865c7fabcf1e99ff0c75de6f7a548cb667e7ed453381ac6&productTypes=products,vouchers&listView=products&products=6932",
+                deniraWidgetId: "qd76n0skbscsqtnrprarjdbpjd82g9vx",
                 longDescription: () => m.experience_calm_long_description()
             },
             {
@@ -97,7 +97,7 @@ export const activities: { paddla: Activity } = {
                     ]
                 },
                 bookingRules: bookingRulesPrivate,
-                bookingLink: "https://app.bookspot.io/widget/v2/dialog/new-order?key=e288265c8bfe259e7865c7fabcf1e99ff0c75de6f7a548cb667e7ed453381ac6&productTypes=products,vouchers&listView=products&products=7297&products=7294&products=7280",
+                deniraWidgetId: "qd7fs9v9k8pvzrem904h0cy1g182h796",
                 longDescription: () => m.experience_adventure_long_description()
             },
             {
@@ -159,7 +159,7 @@ export const activities: { paddla: Activity } = {
                     ]
                 },
                 bookingRules: bookingRulesPrivate,
-                bookingLink: "https://app.bookspot.io/widget/v2/dialog/new-order?key=e288265c8bfe259e7865c7fabcf1e99ff0c75de6f7a548cb667e7ed453381ac6&productTypes=products,vouchers&listView=products&products=7287&products=9280&products=9279",
+                deniraWidgetId: "qd71vpr36wz9b095sxs0ar0p5183876c",
                 longDescription: () => m.experience_challenging_long_description()
             },
             /*{
@@ -311,7 +311,7 @@ export const activities: { paddla: Activity } = {
                     }
                 },
                 bookingRules: bookingRulesCorporate,
-                bookingLink: "https://app.bookspot.io/widget/v2/dialog/new-order?key=e288265c8bfe259e7865c7fabcf1e99ff0c75de6f7a548cb667e7ed453381ac6&productTypes=products,vouchers&listView=products&products=7288",
+                deniraWidgetId: "qd7576grgwm6szhy47jhev2b0n839gjk",
                 longDescription: () => m.experience_corporate_long_description()
             },
             {
@@ -366,7 +366,7 @@ export const activities: { paddla: Activity } = {
                     perInstructor: 8
                 },
                 bookingRules: bookingRulesSchool,
-                bookingLink: "https://app.bookspot.io/widget/v2/dialog/new-order?key=e288265c8bfe259e7865c7fabcf1e99ff0c75de6f7a548cb667e7ed453381ac6&productTypes=products,vouchers&listView=products&products=7298",
+                deniraWidgetId: "qd7ewhhjj9jf49kcnm0rgkg4d5838qgp",
                 longDescription: () => m.experience_school_long_description()
             }
         ]

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,7 +48,7 @@ export interface Experience {
     };
     longDescription: string | (() => string);
     bookingRules: string[] | (() => string)[] | (() => string[]);
-    bookingLink?: string;
+    deniraWidgetId?: string;
 };
 
 export interface PriceTable {

--- a/src/routes/presentkort/+page.svelte
+++ b/src/routes/presentkort/+page.svelte
@@ -39,8 +39,6 @@
 		}
 	];
 
-	const checkoutUrl =
-		'https://app.outventures.se/widget/v2/dialog/new-order?key=e288265c8bfe259e7865c7fabcf1e99ff0c75de6f7a548cb667e7ed453381ac6&productTypes=products,vouchers&listView=products&categories=884';
 </script>
 
 <div class="min-h-screen bg-gradient-to-b from-gray-50 to-white py-24">
@@ -66,15 +64,10 @@
 			{/each}
 		</div>
 
-		<div class="md:mt-12 md:text-center">
-			<a
-				href={checkoutUrl}
-				class="fixed bottom-4 right-4 z-50 rounded-lg bg-blue-600 px-6 py-3 text-lg font-semibold text-white shadow-lg transition-colors duration-200 hover:bg-blue-700 md:static md:inline-block md:px-8 md:py-4 md:shadow-none"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				{m.low_tidy_shell_dust()}
-			</a>
+		<div class="mt-12">
+			<div class="mx-auto w-full max-w-5xl">
+				<div data-denira-widget="qd71esza2a1sgrm8w6s7qp7d7d8386g4"></div>
+			</div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace Bookspot booking links with Denira widget embeds across activity and gift card pages
- Loads the Denira widget script globally via [app.html](https://github.com/SvejoDev/stissesWeb/pull/44/files#diff-c279397c4feb4b0067eda16dfafc3453d18caa9afcc11de4d368411fefc03601), which hydrates `data-denira-widget` placeholder divs on every page.
- Updates [BookingButton.svelte](https://github.com/SvejoDev/stissesWeb/pull/44/files#diff-60ca615c0663935d2f064558481ff8dded29da8fd1ea1aa686bb7b7c9b1693ca) to accept a `widgetId` prop and render a `data-denira-widget` div instead of a clickable link; removes `bookingLink` and `sticky` props.
- Replaces `bookingLink` with `deniraWidgetId` in the `Experience` type and in [paddla.ts](https://github.com/SvejoDev/stissesWeb/pull/44/files#diff-742b90dd1c59a69ce3f622d607189d90ff08e0050bc6d38c4ab374b03a912f71) activity data.
- Replaces the external checkout link on the gift card page with a Denira widget placeholder.
- Behavioral Change: booking and gift card flows are now handled entirely by the Denira widget script rather than external links.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7635c35.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->