### PR TITLE
Uppdatera paddelpriser och fixa Vite-starten

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2955,9 +2955,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001690",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-			"integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
+			"version": "1.0.30001793",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+			"integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
 			"dev": true,
 			"funding": [
 				{

--- a/src/lib/data/activities/paddla.ts
+++ b/src/lib/data/activities/paddla.ts
@@ -360,10 +360,16 @@ export const activities: { paddla: Activity } = {
                             price: 290
                         },
                         {
+                            start: () => m.common_location_ugglarp(),
+                            goal: () => m.common_location_stisses(),
+                            duration: () => m.common_duration_one_overnight(),
+                            price: 792
+                        },
+                        {
                             start: () => m.common_location_tranarpsbron(),
                             goal: () => m.common_location_stisses(),
                             duration: () => m.common_duration_one_overnight(),
-                            price: 590
+                            price: 792
                         }
                     ]
                 },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,15 @@
-import { sveltekit } from "@sveltejs/kit/vite"
-import { paraglide } from "@inlang/paraglide-sveltekit/vite"
+import { createRequire } from "node:module"
 import { defineConfig } from "vite"
 import type { ServerOptions } from 'vite'
+
+const require = createRequire(import.meta.url)
+const buffer = require('node:buffer') as typeof import('node:buffer') & {
+	SlowBuffer?: typeof Buffer
+}
+
+// Compatibility for transitive dependencies that still expect SlowBuffer on
+// newer Node versions while Vite loads the Paraglide plugin.
+buffer.SlowBuffer ??= buffer.Buffer
 
 declare module 'vite' {
 	interface ServerOptions {
@@ -9,23 +17,30 @@ declare module 'vite' {
 	}
 }
 
-export default defineConfig({
-	plugins: [
-		paraglide({
-			project: "./project.inlang",
-			outdir: "./src/lib/paraglide",
-		}),
-		sveltekit(),
-	],
-	server: {
-		port: 3000,
-		host: true,
-		strictPort: true,
-		allowedHosts: ['stisses.se', 'localhost']
-	},
-	preview: {
-		port: 3000,
-		host: true,
-		strictPort: true
+export default defineConfig(async () => {
+	const [{ sveltekit }, { paraglide }] = await Promise.all([
+		import("@sveltejs/kit/vite"),
+		import("@inlang/paraglide-sveltekit/vite")
+	])
+
+	return {
+		plugins: [
+			paraglide({
+				project: "./project.inlang",
+				outdir: "./src/lib/paraglide",
+			}),
+			sveltekit(),
+		],
+		server: {
+			port: 3000,
+			host: true,
+			strictPort: true,
+			allowedHosts: ['stisses.se', 'localhost']
+		},
+		preview: {
+			port: 3000,
+			host: true,
+			strictPort: true
+		}
 	}
 })


### PR DESCRIPTION
## Summary
- Lägger till Ugglarp som alternativ med 1 övernattning för 792 kr i `Lärande friluftsliv`
- Justerar Tranarpsbron till 792 kr för samma upplägg
- Lägger till en liten Node-kompatibilitet i `vite.config.ts` så dev-servern startar på nyare Node-versioner
- Uppdaterar `caniuse-lite` i låsfilen

## Testing
- `npm run check` passerar
- Lokal `npm run dev` verifierad efter fixen